### PR TITLE
Fix version import requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 surfinBH==1.1.8
-pyRingGW==2.3.0
+pyRingGW>=2.3.0
 numpy==1.23.5
 statsmodels==0.13.5
 joypy==0.2.6


### PR DESCRIPTION
pyRing 2.3.0 can throw an error with scipy (due to tukey moving). This patch sets the minimum version of pyRing to 2.3.0, but allows for older versions